### PR TITLE
Add another uuid file - requirement for sparse checkout tests

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-uuid.txt filter=lfs diff=lfs merge=lfs -text
+uuid*.txt filter=lfs diff=lfs merge=lfs -text

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # tests/largeFileSupport branch for git client plugin tests
 
 The Jenkins git-client-plugin large file support tests need a
-repository which contains a branch named tests/largeFileSupport and
-which contains a large file named uuid.txt that contains the string
-5e7733d8acc94636850cb466aec524e4.  
+repository which contains a branch named tests/largeFileSupport.
+It contains multiple large files with string content as follows:
+* uuid.txt - 5e7733d8acc94636850cb466aec524e4
+* uuid2.txt - c49d89a61c3411e9a5555b2af3892239
 
 The GitHub billing rules require that if a forked repository uses large
 files, then the upstream repository must use large files, and the GitHub

--- a/uuid2.txt
+++ b/uuid2.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7f0bbf4cdb2bdf3e862c5f00285d362db0b46465ed089775743ce1ebe6c912ce
+size 33


### PR DESCRIPTION
This is required to implement LFS sparse checkout tests for jenkinsci/git-client-plugin#302.

Only with multiple LFS files it's possible to properly test LFS sparse checkout support.