### PR TITLE
Add more LFS files - requirement for sparse checkout tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,10 @@
 The Jenkins git-client-plugin large file support tests need a
 repository which contains a branch named tests/largeFileSupport.
 It contains multiple large files with string content as follows:
-* uuid.txt - 5e7733d8acc94636850cb466aec524e4
-* uuid2.txt - c49d89a61c3411e9a5555b2af3892239
+* "uuid.txt" - 5e7733d8acc94636850cb466aec524e4
+* "uuid2.txt" - c49d89a61c3411e9a5555b2af3892239
+* "uuid,3.txt" - 6fd3199a1cb111e9bbaf537fc996ab9b
+* "uuid 4.txt" - 803219bc1cb111e9abbfb7cc7b029948
 
 The GitHub billing rules require that if a forked repository uses large
 files, then the upstream repository must use large files, and the GitHub

--- a/uuid 4.txt
+++ b/uuid 4.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:44a0d97ff32b5ba6a28ea8a35d1ebbfd8f9a8a2db316e87abd530b4b60153b5c
+size 33

--- a/uuid,3.txt
+++ b/uuid,3.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1e359899b05181e6a118865d47ed027b9930bc870dffbd9608c609ec3b2a3d16
+size 33


### PR DESCRIPTION
This is required to implement LFS sparse checkout tests for jenkinsci/git-client-plugin#302.

Only with these files it's possible to test the support of comma "," and space " " in LFS file paths.